### PR TITLE
Moderation, code optimisation and plural

### DIFF
--- a/approved-images.blade.php
+++ b/approved-images.blade.php
@@ -1,0 +1,288 @@
+<?php
+
+use Livewire\Volt\Component;
+use App\Models\Wall;
+use App\Models\Image;
+use Mary\Traits\Toast;
+use Illuminate\Support\Facades\Storage;
+use Livewire\WithPagination;
+use Livewire\WithoutUrlPagination;
+
+
+new class extends Component {
+    use Toast, WithPagination, WithoutUrlPagination;
+
+    public Wall $wall;
+    public array $selectedImages = [];
+    public int $approvedImagesPageCount = 0;
+
+
+    /*public function mount(Wall $wall)
+    {
+        $this->images = Image::where('wall_id', $wall->id)->get();
+    }*/
+
+    public function mount(Wall $wall)
+    {
+        $this->wall = $wall;
+    }
+
+    public function approvedImages()
+    {
+        $images = Image::where('wall_id', $this->wall->id)
+                    ->where('approved', true)
+                    ->orderBy('created_at', 'desc')
+                    ->paginate(5, pageName: 'approved-images');
+        
+        $this->approvedImagesPageCount = $images->count();
+        return $images;
+    }
+
+    protected $listeners = ['reset-selection-approved' => '$refresh', 'approved-images-updated' => '$refresh'];
+
+
+
+    // Archiving images //
+    public function archiveImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+       Image::where('id', $id)->update(['archived' => true, 'approved' => false]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->approvedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'approved-images');
+        }
+        //  Émission d’événement Livewire vers le composant archived-images
+        $this->dispatch('archived-images-updated');
+        $this->success(__('Image archived successfully.'));
+    }
+
+    public function archiveSelected(array $selectedImages)
+    {
+        
+        if (empty($selectedImages)) {
+            $this->error(__('No image selected.'));
+            return;
+        }
+
+        Image::whereIn('id', $selectedImages)->update(['archived' => true, 'approved' => false]);
+
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection-approved');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->approvedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'approved-images');
+        }
+        //  Émission d’événement Livewire vers le composant archived-images
+        $this->dispatch('archived-images-updated');
+        $this->success(__('Selected images archived.'));
+    }
+   
+
+
+
+    // Delete images //
+    public function deleteImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+        $image = Image::where('id', $id)->first(['id', 'name', 'thumb']);
+    
+        if (!$image) {
+            $this->error(__('Image not found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers
+        Storage::disk('public')->delete([$image->name, $image->thumb]);
+    
+        // Supprimer l'image de la base de données
+        $image->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->approvedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'approved-images');
+        }
+        $this->success(__('Photo deleted successfully.'));
+    }
+
+    public function deleteSelected(array $selectedImages)
+    {
+       
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+    
+        // Récupérer directement les chemins sous forme de liste plate
+        $paths = Image::whereIn('id', $selectedImages)->pluck('name')->merge(
+            Image::whereIn('id', $selectedImages)->pluck('thumb')
+        )->toArray();
+    
+        if (empty($paths)) {
+            $this->error(__('No valid images found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers en une seule requête
+        Storage::disk('public')->delete($paths);
+    
+        // Supprimer les entrées de la base de données
+        Image::whereIn('id', $selectedImages)->delete();
+    
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection-approved');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->approvedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'approved-images');
+        }
+        $this->success(__('Selected images deleted.'));
+    }
+    
+}; ?>
+
+<div x-data="{ selectedApproved: [], allSelectedApproved: false, errorMessage : '',
+        showConfirmModal: false, 
+        modalTitle: '', 
+        modalMessage: '', 
+        modalConfirmText: '', 
+        modalConfirmClass: 'bg-blue-600 hover:bg-blue-700', 
+        confirmAction: null,
+        showImageZoomModal: false,
+        modalImageUrl: '' }" @reset-selection-approved.window="selectedApproved = []; allSelectedApproved = false">
+
+<div class="galery_data">
+    <h2>{{ __( 'Approved images' ) }}</h2>
+</div>
+
+<div class="bulk-actions flex items-center">
+    <button class="btn btn-sm" @click="allSelectedApproved = !allSelectedApproved; selectedApproved = allSelectedApproved ? [...document.querySelectorAll('.approved-image-checkbox')].map(cb => cb.value) : []">
+        <label for="approved-select-all-checkbox" @click="allSelectedApproved = !allSelectedApproved; selectedApproved = allSelectedApproved ? [...document.querySelectorAll('.approved-image-checkbox')].map(cb => cb.value) : []" class="cursor-pointer">Select All</label>
+        <input 
+            type="checkbox"
+            id="approved-select-all-checkbox"
+            class="checkbox"
+            x-model="allSelectedApproved"
+        />
+    </button>
+
+    <x-button 
+        @click="if (selectedApproved.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selectedApproved.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Archive images') }}',
+                        message: '{{ __('You are about to archive') }} ' + selectedApproved.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, archive!') }}',
+                        confirmClass: 'bg-blue-600 hover:bg-blue-700',
+                        action: () => $wire.call('archiveSelected', selectedApproved)
+                    })
+                }
+            "
+        icon="o-archive-box"
+        class="btn btn-sm"
+        tooltip="{{ __('Archive selected') }}"
+        aria-label="{{ __('Archive selected') }}"
+    />
+    <x-button     
+        @click="
+                if (selectedApproved.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selectedApproved.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Delete images') }}',
+                        message: '{{ __('You are about to delete') }} ' + selectedApproved.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, delete !') }}',
+                        confirmClass: 'bg-red-600 hover:bg-red-700',
+                        action: () => $wire.call('deleteSelected', selectedApproved)
+                    })
+                }
+            "
+        icon="o-trash"
+        class="btn btn-sm btn-danger"
+        wire:click.prevent=""
+        tooltip="{{ __('Delete Selected') }}"
+        aria-label="{{ __('Delete Selected') }}"
+    />
+    <!-- Message d'erreur affiché dynamiquement -->
+    <p x-show="errorMessage" x-text="errorMessage" class="text-red-500 mt-2 transition-opacity duration-500"></p>
+    <p wire:loading>Please wait...</p>
+</div>
+
+
+<div class="gallery_wrapper">
+
+    @if($this->approvedImages()->isEmpty())
+        <p class="text-center text-gray-500">{{ __('No approved image.') }}</p>
+    @else
+    @foreach($this->approvedImages() as $image)
+        @php
+        if ($image->caption) {
+            $data1 = "tooltip tooltip-bottom";
+            $data2 = "$image->caption";
+            $data3 = "";
+        } else {
+            $data1 = "";
+            $data2 = "";
+            $data3 = "hidden";
+        }
+    @endphp
+        <div class="image_wrapper {{ ( $data1 ) }}" data-tip="{!! $data2 !!}" wire:key="image-{{ $image->id }}">
+            <div class="uper_image_data justify-between">
+                <a role="button" @click="$dispatch('open-image-modal', { url: '{{ asset('public/storage/' . $image->name) }}' })">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
+                    </svg>
+                </a>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 {{ ( $data3 ) }}">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                </svg>
+            <input 
+                type="checkbox" 
+                class="checkbox checkbox-sm approved-image-checkbox"
+                :value="{{ $image->id }}"
+                x-model="selectedApproved"
+                id="checkbox-{{ $image->id }}"
+            />
+            </div>
+                <label for="checkbox-{{ $image->id }}" display="block">
+                    <img src="{{ asset('public/storage/' . $image->thumb) }}" />
+                </label>
+            <div class="moderation_buttons flex justify-between">
+                <x-button 
+                    wire:click="archiveImage({{ $image->id }})"
+                    icon="o-archive-box"
+                    class="btn btn-sm"
+                    tooltip="{{ __('Archive Selected') }}"
+                    aria-label="{{ __('Archive Selected') }}"
+                    @click="$wire.set('selectedImages', selectedApproved)"
+                />
+                <x-button 
+                    wire:click.prevent=""
+                    icon="o-trash"
+                    class="btn btn-sm btn-danger"
+                    tooltip="{{ __('Delete image') }}"
+                    aria-label="{{ __('Delete image') }}"
+                    @click="
+                        $dispatch('confirm-action', {
+                            title: '{{ __('Delete image') }}',
+                            message: '{{ __('Are you sure you want to delete this image?') }}',
+                            confirmText: '{{ __('Yes, delete!') }}',
+                            confirmClass: 'bg-red-600 hover:bg-red-700',
+                            action: () => $wire.call('deleteImage', {{ $image->id }})
+                        })
+                    "
+                />
+            </div>
+        </div>
+        @endforeach
+    @endif
+</div>
+<div class="galerie-navigation flex justify-evenly">
+    {{ $this->approvedImages()->links(data: ['scrollTo' => false]) }}
+</div>
+
+</div>

--- a/archived-images.blade.php
+++ b/archived-images.blade.php
@@ -1,0 +1,287 @@
+<?php
+
+use Livewire\Volt\Component;
+use App\Models\Wall;
+use App\Models\Image;
+use Intervention\Image\ImageManager;
+use Mary\Traits\Toast;
+use Illuminate\Support\Facades\Storage;
+use Livewire\WithPagination;
+use Livewire\WithoutUrlPagination;
+
+new class extends Component {
+    use Toast, WithPagination, WithoutUrlPagination;
+
+    public Wall $wall;
+    public array $selectedImages = [];
+    public int $archivedImagesPageCount = 0;
+
+    public function mount(Wall $wall)
+    {
+        $this->wall = $wall;
+    }
+
+    public function archivedImages()
+    {
+        $images = Image::where('wall_id', $this->wall->id)
+                    ->where('archived', true)
+                    ->orderBy('created_at', 'desc')
+                    ->paginate(5, pageName: 'archived-images');
+
+        $this->archivedImagesPageCount = $images->count();
+        return $images;
+    }
+
+    protected $listeners = ['reset-selection-archived' => '$refresh', 'archived-images-updated' => '$refresh',];
+
+
+
+    // Approving images //
+    public function approveImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+       Image::where('id', $id)->update(['approved' => true, 'archived' => false]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Photo approved successfully.'));
+    }
+
+    public function approveSelected(array $selectedImages)
+    {
+        
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+
+        Image::whereIn('id', $selectedImages)->update(['approved' => true, 'archived' => false]);
+
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection-archived');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Selected images approved.'));
+    }
+    
+
+
+
+    // Deleting images //    
+    public function deleteImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+        $image = Image::where('id', $id)->first(['id', 'name', 'thumb']);
+    
+        if (!$image) {
+            $this->error(__('Image not found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers
+        Storage::disk('public')->delete([$image->name, $image->thumb]);
+    
+        // Supprimer l'image de la base de données
+        $image->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        $this->success(__('Photo deleted successfully.'));
+    }
+
+    public function deleteSelected(array $selectedImages)
+    {
+       
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+    
+        // Récupérer directement les chemins sous forme de liste plate
+        $paths = Image::whereIn('id', $selectedImages)->pluck('name')->merge(
+            Image::whereIn('id', $selectedImages)->pluck('thumb')
+        )->toArray();
+    
+        if (empty($paths)) {
+            $this->error(__('No valid images found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers en une seule requête
+        Storage::disk('public')->delete($paths);
+    
+        // Supprimer les entrées de la base de données
+        Image::whereIn('id', $selectedImages)->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection-archived');    
+        $this->success(__('Selected images deleted.'));
+    }
+
+        
+}; ?>
+
+<div x-data="{ selectedArchived: [], allSelected: false,  errorMessage : '',
+        showConfirmModal: false, 
+        modalTitle: '', 
+        modalMessage: '', 
+        modalConfirmText: '', 
+        modalConfirmClass: 'bg-blue-600 hover:bg-blue-700', 
+        confirmAction: null,
+        showImageZoomModal: false,
+        modalImageUrl: '' }" @reset-selection-archived.window="selectedArchived = []; allSelected = false,  errorMessage = ''">
+
+<div class="galery_data">
+    <h2>{{ __( 'Archived images' ) }}</h2>
+</div>
+
+<div class="bulk-actions flex items-center">
+    <button class="btn btn-sm" @click="allSelected = !allSelected; selectedArchived = allSelected ? [...document.querySelectorAll('.archived-image-checkbox')].map(cb => cb.value) : []">
+        <label for="select-all-checkbox" @click="allSelected = !allSelected; selectedArchived = allSelected ? [...document.querySelectorAll('.archived-image-checkbox')].map(cb => cb.value) : []" class="cursor-pointer">Select All</label>
+        <input 
+            type="checkbox"
+            id="select-all-checkbox"
+            class="checkbox"
+            x-model="allSelected"
+        />
+    </button>
+
+    <x-button 
+        @click="
+                if (selectedArchived.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selectedArchived.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Approve images') }}',
+                        message: '{{ __('You are about to approve') }} ' + selectedArchived.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, approve !') }}',
+                        confirmClass: 'bg-green-600 hover:bg-green-700',
+                        action: () => $wire.call('approveSelected', selectedArchived)
+                    })
+                }
+            "
+        icon="o-check"
+        class="btn btn-sm"
+        tooltip="{{ __('Approve Selected') }}"
+        aria-label="{{ __('Approve Selected') }}"
+    />
+
+    <x-button     
+        @click="
+                if (selectedArchived.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selectedArchived.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Delete images') }}',
+                        message: '{{ __('You are about to delete') }} ' + selectedArchived.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, delete !') }}',
+                        confirmClass: 'bg-red-600 hover:bg-red-700',
+                        action: () => $wire.call('deleteSelected', selectedArchived)
+                    })
+                }
+            "
+        icon="o-trash"
+        class="btn btn-sm btn-danger"
+        wire:click.prevent=""
+        tooltip="{{ __('Delete Selected') }}"
+        aria-label="{{ __('Delete Selected') }}"
+    />
+    <!-- Message d'erreur affiché dynamiquement -->
+    <p x-show="errorMessage" x-text="errorMessage" class="text-red-500 mt-2 transition-opacity duration-500"></p>
+    <p wire:loading>Please wait...</p>
+    
+</div>
+
+
+<div class="gallery_wrapper">
+
+    @if($this->archivedImages()->isEmpty())
+            <p class="text-center text-gray-500">{{ __('No image pending.') }}</p>
+        @else
+            @foreach($this->archivedImages() as $image)
+            @php
+            if ($image->caption) {
+                $data1 = "tooltip tooltip-bottom";
+                $data2 = "$image->caption";
+                $data3 = "";
+            } else {
+                $data1 = "";
+                $data2 = "";
+                $data3 = "hidden";
+            }
+        @endphp
+        <div class="image_wrapper {{ ( $data1 ) }}" data-tip="{!! $data2 !!}" wire:key="image-{{ $image->id }}">
+            <div class="uper_image_data justify-between">
+                <a role="button" @click="$dispatch('open-image-modal', { url: '{{ asset('public/storage/' . $image->name) }}' })">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
+                    </svg>
+                </a>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 {{ ( $data3 ) }}">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                </svg>
+            <input 
+                type="checkbox" 
+                class="checkbox checkbox-sm archived-image-checkbox"
+                :value="{{ $image->id }}"
+                x-model="selectedArchived"
+                id="checkbox-{{ $image->id }}"
+            />
+            </div>
+                <label for="checkbox-{{ $image->id }}" display="block">
+                    <img src="{{ asset('public/storage/' . $image->thumb) }}" />
+                </label>
+            <div class="moderation_buttons flex justify-between">
+                <x-button 
+                    wire:click="approveImage({{ $image->id }})"
+                    icon="o-check"
+                    class="btn btn-sm"
+                    tooltip="{{ __('Approve image') }}"
+                    aria-label="{{ __('Approve image') }}"
+                    @click="$wire.set('selectedImages', selectedArchived)"
+                />
+                <x-button 
+                    wire:click.prevent=""
+                    icon="o-trash"
+                    class="btn btn-sm btn-danger"
+                    tooltip="{{ __('Delete image') }}"
+                    aria-label="{{ __('Delete image') }}"
+                    @click="
+                        $dispatch('confirm-action', {
+                            title: '{{ __('Delete image') }}',
+                            message: '{{ __('Are you sure you want to delete this image?') }}',
+                            confirmText: '{{ __('Yes, delete!') }}',
+                            confirmClass: 'bg-red-600 hover:bg-red-700',
+                            action: () => $wire.call('deleteImage', {{ $image->id }})
+                        })
+                    "
+                />
+            </div>
+        </div>
+        @endforeach
+    @endif
+</div>
+
+<div class="galerie-navigation flex justify-evenly">
+    {{ $this->archivedImages()->links(data: ['scrollTo' => false]) }}
+</div>
+
+</div>

--- a/moderation.blade.php
+++ b/moderation.blade.php
@@ -1,0 +1,82 @@
+<?php
+
+use Livewire\Volt\Component;
+use App\Models\Wall;
+use App\Models\Image;
+use Intervention\Image\ImageManager;
+use Mary\Traits\Toast;
+use Illuminate\Support\Facades\Storage;
+
+new class extends Component {
+    use Toast;
+
+    public Wall $wall;
+        
+}; ?>
+
+<div 
+    x-data="{
+        showImageZoomModal: false,
+        modalImageUrl: '',
+        showConfirmModal: false,
+        modalTitle: '',
+        modalMessage: '',
+        modalConfirmText: '',
+        modalConfirmClass: '',
+        confirmAction: null
+    }"
+    @open-image-modal.window="modalImageUrl = $event.detail.url; showImageZoomModal = true"
+    @confirm-action.window="
+        modalTitle = $event.detail.title;
+        modalMessage = $event.detail.message;
+        modalConfirmText = $event.detail.confirmText;
+        modalConfirmClass = $event.detail.confirmClass || 'bg-blue-600 hover:bg-blue-700';
+        confirmAction = $event.detail.action;
+        showConfirmModal = true;"
+    x-cloak
+>
+    <div class="wall_data">
+        <h1>{{ __( $wall->name ) }}</h1>
+        <h3>{{ __( $wall->description ) }}</h3>
+    </div>
+
+    <livewire:walls.unprocessed-images :wall="$wall" />
+    <livewire:walls.approved-images :wall="$wall" />
+    <livewire:walls.archived-images :wall="$wall" />
+
+    <!-- Zoom Image Modal -->
+    <div 
+        x-show="showImageZoomModal"
+        @click="showImageZoomModal = false"
+        x-transition 
+        class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50"
+    >
+        <div class="shadow-lg overflow-auto relative">
+            <div class="close-button-wrapper">
+                <x-button @click="showImageZoomModal = false" class="btn btn-sm" icon="o-x-mark" />
+            </div>
+            <img :src="modalImageUrl" alt="Image Preview" class="w-full h-auto mt-4" />
+        </div>
+    </div>
+
+    <!-- Confirmation Modal -->
+    <div 
+        x-show="showConfirmModal"
+        x-transition
+        class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50"
+    >
+        <div class="bg-white p-6 rounded-lg shadow-lg w-96 overflow-auto relative">
+            <h2 class="text-lg font-semibold" x-text="modalTitle"></h2>
+            <p class="mt-2 text-gray-600" x-text="modalMessage"></p>
+
+            <div class="mt-4 flex justify-end space-x-2">
+                <button @click="showConfirmModal = false" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">
+                    {{ __('Cancel') }}
+                </button>
+                <button @click="confirmAction(); showConfirmModal = false" class="px-4 py-2 text-white rounded" :class="modalConfirmClass">
+                    <span x-text="modalConfirmText"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/walls/archived-images.blade.php
+++ b/resources/views/livewire/walls/archived-images.blade.php
@@ -1,0 +1,287 @@
+<?php
+
+use Livewire\Volt\Component;
+use App\Models\Wall;
+use App\Models\Image;
+use Intervention\Image\ImageManager;
+use Mary\Traits\Toast;
+use Illuminate\Support\Facades\Storage;
+use Livewire\WithPagination;
+use Livewire\WithoutUrlPagination;
+
+new class extends Component {
+    use Toast, WithPagination, WithoutUrlPagination;
+
+    public Wall $wall;
+    public array $selectedImages = [];
+    public int $archivedImagesPageCount = 0;
+
+    public function mount(Wall $wall)
+    {
+        $this->wall = $wall;
+    }
+
+    public function archivedImages()
+    {
+        $images = Image::where('wall_id', $this->wall->id)
+                    ->where('archived', true)
+                    ->orderBy('created_at', 'desc')
+                    ->paginate(5, pageName: 'archived-images');
+
+        $this->archivedImagesPageCount = $images->count();
+        return $images;
+    }
+
+    protected $listeners = ['reset-selection-archived' => '$refresh', 'archived-images-updated' => '$refresh',];
+
+
+
+    // Approving images //
+    public function approveImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+       Image::where('id', $id)->update(['approved' => true, 'archived' => false]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Photo approved successfully.'));
+    }
+
+    public function approveSelected(array $selectedImages)
+    {
+        
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+
+        Image::whereIn('id', $selectedImages)->update(['approved' => true, 'archived' => false]);
+
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection-archived');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Selected images approved.'));
+    }
+    
+
+
+
+    // Deleting images //    
+    public function deleteImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+        $image = Image::where('id', $id)->first(['id', 'name', 'thumb']);
+    
+        if (!$image) {
+            $this->error(__('Image not found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers
+        Storage::disk('public')->delete([$image->name, $image->thumb]);
+    
+        // Supprimer l'image de la base de données
+        $image->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        $this->success(__('Photo deleted successfully.'));
+    }
+
+    public function deleteSelected(array $selectedImages)
+    {
+       
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+    
+        // Récupérer directement les chemins sous forme de liste plate
+        $paths = Image::whereIn('id', $selectedImages)->pluck('name')->merge(
+            Image::whereIn('id', $selectedImages)->pluck('thumb')
+        )->toArray();
+    
+        if (empty($paths)) {
+            $this->error(__('No valid images found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers en une seule requête
+        Storage::disk('public')->delete($paths);
+    
+        // Supprimer les entrées de la base de données
+        Image::whereIn('id', $selectedImages)->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->archivedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'archived-images');
+        }
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection-archived');    
+        $this->success(__('Selected images deleted.'));
+    }
+
+        
+}; ?>
+
+<div x-data="{ selectedArchived: [], allSelected: false,  errorMessage : '',
+        showConfirmModal: false, 
+        modalTitle: '', 
+        modalMessage: '', 
+        modalConfirmText: '', 
+        modalConfirmClass: 'bg-blue-600 hover:bg-blue-700', 
+        confirmAction: null,
+        showImageZoomModal: false,
+        modalImageUrl: '' }" @reset-selection-archived.window="selectedArchived = []; allSelected = false,  errorMessage = ''">
+
+<div class="galery_data">
+    <h2>{{ __( 'Archived images' ) }}</h2>
+</div>
+
+<div class="bulk-actions flex items-center">
+    <button class="btn btn-sm" @click="allSelected = !allSelected; selectedArchived = allSelected ? [...document.querySelectorAll('.archived-image-checkbox')].map(cb => cb.value) : []">
+        <label for="select-all-checkbox" @click="allSelected = !allSelected; selectedArchived = allSelected ? [...document.querySelectorAll('.archived-image-checkbox')].map(cb => cb.value) : []" class="cursor-pointer">Select All</label>
+        <input 
+            type="checkbox"
+            id="select-all-checkbox"
+            class="checkbox"
+            x-model="allSelected"
+        />
+    </button>
+
+    <x-button 
+        @click="
+                if (selectedArchived.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selectedArchived.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Approve images') }}',
+                        message: '{{ __('You are about to approve') }} ' + selectedArchived.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, approve !') }}',
+                        confirmClass: 'bg-green-600 hover:bg-green-700',
+                        action: () => $wire.call('approveSelected', selectedArchived)
+                    })
+                }
+            "
+        icon="o-check"
+        class="btn btn-sm"
+        tooltip="{{ __('Approve Selected') }}"
+        aria-label="{{ __('Approve Selected') }}"
+    />
+
+    <x-button     
+        @click="
+                if (selectedArchived.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selectedArchived.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Delete images') }}',
+                        message: '{{ __('You are about to delete') }} ' + selectedArchived.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, delete !') }}',
+                        confirmClass: 'bg-red-600 hover:bg-red-700',
+                        action: () => $wire.call('deleteSelected', selectedArchived)
+                    })
+                }
+            "
+        icon="o-trash"
+        class="btn btn-sm btn-danger"
+        wire:click.prevent=""
+        tooltip="{{ __('Delete Selected') }}"
+        aria-label="{{ __('Delete Selected') }}"
+    />
+    <!-- Message d'erreur affiché dynamiquement -->
+    <p x-show="errorMessage" x-text="errorMessage" class="text-red-500 mt-2 transition-opacity duration-500"></p>
+    <p wire:loading>Please wait...</p>
+    
+</div>
+
+
+<div class="gallery_wrapper">
+
+    @if($this->archivedImages()->isEmpty())
+            <p class="text-center text-gray-500">{{ __('No image pending.') }}</p>
+        @else
+            @foreach($this->archivedImages() as $image)
+            @php
+            if ($image->caption) {
+                $data1 = "tooltip tooltip-bottom";
+                $data2 = "$image->caption";
+                $data3 = "";
+            } else {
+                $data1 = "";
+                $data2 = "";
+                $data3 = "hidden";
+            }
+        @endphp
+        <div class="image_wrapper {{ ( $data1 ) }}" data-tip="{!! $data2 !!}" wire:key="image-{{ $image->id }}">
+            <div class="uper_image_data justify-between">
+                <a role="button" @click="$dispatch('open-image-modal', { url: '{{ asset('public/storage/' . $image->name) }}' })">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
+                    </svg>
+                </a>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 {{ ( $data3 ) }}">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                </svg>
+            <input 
+                type="checkbox" 
+                class="checkbox checkbox-sm archived-image-checkbox"
+                :value="{{ $image->id }}"
+                x-model="selectedArchived"
+                id="checkbox-{{ $image->id }}"
+            />
+            </div>
+                <label for="checkbox-{{ $image->id }}" display="block">
+                    <img src="{{ asset('public/storage/' . $image->thumb) }}" />
+                </label>
+            <div class="moderation_buttons flex justify-between">
+                <x-button 
+                    wire:click="approveImage({{ $image->id }})"
+                    icon="o-check"
+                    class="btn btn-sm"
+                    tooltip="{{ __('Approve image') }}"
+                    aria-label="{{ __('Approve image') }}"
+                    @click="$wire.set('selectedImages', selectedArchived)"
+                />
+                <x-button 
+                    wire:click.prevent=""
+                    icon="o-trash"
+                    class="btn btn-sm btn-danger"
+                    tooltip="{{ __('Delete image') }}"
+                    aria-label="{{ __('Delete image') }}"
+                    @click="
+                        $dispatch('confirm-action', {
+                            title: '{{ __('Delete image') }}',
+                            message: '{{ __('Are you sure you want to delete this image?') }}',
+                            confirmText: '{{ __('Yes, delete!') }}',
+                            confirmClass: 'bg-red-600 hover:bg-red-700',
+                            action: () => $wire.call('deleteImage', {{ $image->id }})
+                        })
+                    "
+                />
+            </div>
+        </div>
+        @endforeach
+    @endif
+</div>
+
+<div class="galerie-navigation flex justify-evenly">
+    {{ $this->archivedImages()->links(data: ['scrollTo' => false]) }}
+</div>
+
+</div>

--- a/resources/views/livewire/walls/moderation.blade.php
+++ b/resources/views/livewire/walls/moderation.blade.php
@@ -6,28 +6,77 @@ use App\Models\Image;
 use Intervention\Image\ImageManager;
 use Mary\Traits\Toast;
 use Illuminate\Support\Facades\Storage;
-use Livewire\WithPagination;
-use Livewire\WithoutUrlPagination;
-
 
 new class extends Component {
     use Toast;
-    use WithPagination, WithoutUrlPagination;
 
     public Wall $wall;
         
 }; ?>
 
-<div>
+<div 
+    x-data="{
+        showImageZoomModal: false,
+        modalImageUrl: '',
+        showConfirmModal: false,
+        modalTitle: '',
+        modalMessage: '',
+        modalConfirmText: '',
+        modalConfirmClass: '',
+        confirmAction: null
+    }"
+    @open-image-modal.window="modalImageUrl = $event.detail.url; showImageZoomModal = true"
+    @confirm-action.window="
+        modalTitle = $event.detail.title;
+        modalMessage = $event.detail.message;
+        modalConfirmText = $event.detail.confirmText;
+        modalConfirmClass = $event.detail.confirmClass || 'bg-blue-600 hover:bg-blue-700';
+        confirmAction = $event.detail.action;
+        showConfirmModal = true;"
+    x-cloak
+>
+    <div class="wall_data">
+        <h1>{{ __( $wall->name ) }}</h1>
+        <h3>{{ __( $wall->description ) }}</h3>
+    </div>
 
-<div class="wall_data">
-    <h1>{{ __( $wall->name ) }}</h1>
-    <h3>{{ __( $wall->description ) }}</h3>
-</div>
+    <livewire:walls.unprocessed-images :wall="$wall" />
+    <livewire:walls.approved-images :wall="$wall" />
+    <livewire:walls.archived-images :wall="$wall" />
 
+    <!-- Zoom Image Modal -->
+    <div 
+        x-show="showImageZoomModal"
+        @click="showImageZoomModal = false"
+        x-transition 
+        class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50"
+    >
+        <div class="shadow-lg overflow-auto relative">
+            <div class="close-button-wrapper">
+                <x-button @click="showImageZoomModal = false" class="btn btn-sm" icon="o-x-mark" />
+            </div>
+            <img :src="modalImageUrl" alt="Image Preview" class="w-full h-auto mt-4" />
+        </div>
+    </div>
 
-<livewire:walls.unprocessed-images :wall="$wall" />
+    <!-- Confirmation Modal -->
+    <div 
+        x-show="showConfirmModal"
+        x-transition
+        class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50"
+    >
+        <div class="bg-white p-6 rounded-lg shadow-lg w-96 overflow-auto relative">
+            <h2 class="text-lg font-semibold" x-text="modalTitle"></h2>
+            <p class="mt-2 text-gray-600" x-text="modalMessage"></p>
 
-<livewire:walls.approved-images :wall="$wall" />
-
+            <div class="mt-4 flex justify-end space-x-2">
+                <button @click="showConfirmModal = false" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">
+                    {{ __('Cancel') }}
+                </button>
+                <button @click="confirmAction(); showConfirmModal = false" class="px-4 py-2 text-white rounded" :class="modalConfirmClass">
+                    <span x-text="modalConfirmText"></span>
+                </button>
+            </div>
+        </div>
+    </div>
 </div>

--- a/resources/views/livewire/walls/unprocessed-images.blade.php
+++ b/resources/views/livewire/walls/unprocessed-images.blade.php
@@ -6,32 +6,47 @@ use App\Models\Image;
 use Intervention\Image\ImageManager;
 use Mary\Traits\Toast;
 use Illuminate\Support\Facades\Storage;
-
+use Livewire\WithPagination;
+use Livewire\WithoutUrlPagination;
 
 new class extends Component {
-    use Toast;
+    use Toast, WithPagination, WithoutUrlPagination;
 
-    public Wall $wall;
-    
-    //public $images;
+    public Wall $wall;   
     public array $selectedImages = [];
+    public int $unprocessedImagesPageCount = 0;
 
-    /*public function mount(Wall $wall)
-    {
-        $this->images = Image::where('wall_id', $wall->id)->get();
-    }*/
 
     public function mount(Wall $wall)
     {
         $this->wall = $wall;
     }
 
-    public function images()
+    public function getImagesProperty()
     {
-        return Image::where('wall_id', $this->wall->id)
+        $images = Image::where('wall_id', $this->wall->id)
                     ->where('approved', false)
+                    ->where('archived', false)
                     ->orderBy('created_at', 'desc')
-                    ->get();
+                    ->paginate(5, pageName: 'unprocessed-images');
+
+        $this->unprocessedImagesPageCount = $images->count();
+        return $images;
+    }
+
+    // Approving images //
+    public function approveImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+       Image::where('id', $id)->update(['approved' => true]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Image approved successfully.'));
     }
 
     public function approveSelected(array $selectedImages)
@@ -46,32 +61,77 @@ new class extends Component {
 
         // Réinitialiser la sélection
         $this->dispatch('reset-selection');
-
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
         $this->success(__('Selected images approved.'));
     }
     
-    public function approveImage(int $id): void
+
+    // Archiving images //
+    public function archiveImage(int $id): void
     {
         // Récupérer directement les données nécessaires en une seule requête
-       Image::where('id', $id)->update(['approved' => true]);
+       Image::where('id', $id)->update(['archived' => true]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant archived-images
+        $this->dispatch('archived-images-updated');
+        $this->success(__('Image archived successfully.'));
+    }
+
+    public function archiveSelected(array $selectedImages)
+    {
+        
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+
+        Image::whereIn('id', $selectedImages)->update(['archived' => true]);
 
         // Réinitialiser la sélection
         $this->dispatch('reset-selection');
-
-        $this->success(__('Photo approved successfully.'));
-    }
-
-
-    
-    public function archiveSelected()
-    {
-        Image::whereIn('id', $this->selectedImages)->update(['archived' => true]);
-        $this->images = Image::where('wall_id', $this->wall->id)->where('approved', false)->get();
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant archived-images
+        $this->dispatch('archived-images-updated');
         $this->success(__('Selected images archived.'));
     }
 
 
 
+    // Deleting images //
+    public function deleteImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+        $image = Image::where('id', $id)->first(['id', 'name', 'thumb']);
+    
+        if (!$image) {
+            $this->error(__('Image not found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers
+        Storage::disk('public')->delete([$image->name, $image->thumb]);
+    
+        // Supprimer l'image de la base de données
+        $image->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        $this->success(__('Image deleted successfully.'));
+    }
 
     public function deleteSelected(array $selectedImages)
     {
@@ -99,32 +159,11 @@ new class extends Component {
 
         // Réinitialiser la sélection
         $this->dispatch('reset-selection');
-
-    
-        $this->success(__('Selected images deleted.'));
-    }
-    
-    
-    public function deleteImage(int $id): void
-    {
-        // Récupérer directement les données nécessaires en une seule requête
-        $image = Image::where('id', $id)->first(['id', 'name', 'thumb']);
-    
-        if (!$image) {
-            $this->error(__('Image not found.'));
-            return;
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
         }
-    
-        // Supprimer les fichiers
-        Storage::disk('public')->delete([$image->name, $image->thumb]);
-    
-        // Supprimer l'image de la base de données
-        $image->delete();
-
-        // Réinitialiser la sélection
-        $this->dispatch('reset-selection');
-    
-        $this->success(__('Photo deleted successfully.'));
+        $this->success(__('Selected images deleted.'));
     }
         
 }; ?>
@@ -135,15 +174,17 @@ new class extends Component {
         modalMessage: '', 
         modalConfirmText: '', 
         modalConfirmClass: 'bg-blue-600 hover:bg-blue-700', 
-        confirmAction: null }" @reset-selection.window="selected = []; allSelected = false,  errorMessage = ''">
+        confirmAction: null,        
+        showImageZoomModal: false,
+        modalImageUrl: '' }" @reset-selection.window="selected = []; allSelected = false,  errorMessage = ''">
 
 <div class="galery_data">
     <h2>{{ __( 'Pending images' ) }}</h2>
 </div>
 
 <div class="bulk-actions flex items-center">
-    <button class="btn btn-sm" @click="allSelected = !allSelected; selected = allSelected ? [...document.querySelectorAll('.image-checkbox')].map(cb => cb.value) : []">
-        <label for="select-all-checkbox" @click="allSelected = !allSelected; selected = allSelected ? [...document.querySelectorAll('.image-checkbox')].map(cb => cb.value) : []" class="cursor-pointer">Select All</label>
+    <button class="btn btn-sm" @click="allSelected = !allSelected; selected = allSelected ? [...document.querySelectorAll('.unprocessed-image-checkbox')].map(cb => cb.value) : []">
+        <label for="select-all-checkbox" @click="allSelected = !allSelected; selected = allSelected ? [...document.querySelectorAll('.unprocessed-image-checkbox')].map(cb => cb.value) : []" class="cursor-pointer">Select All</label>
         <input 
             type="checkbox"
             id="select-all-checkbox"
@@ -158,16 +199,14 @@ new class extends Component {
                     errorMessage = '{{ __('No images selected.') }}'; 
                     setTimeout(() => errorMessage = '', 1500);
                 } else {
-                    modalTitle = '{{ __('Approve Images') }}';
-                    modalMessage = '{{ __('You are about to approve') }} ' + selected.length + ' {{ __('images.') }}';
-                    modalConfirmText = '{{ __('Yes, approve !') }}';
-                    modalConfirmClass = 'bg-green-600 hover:bg-green-700';
-                    showConfirmModal = true; 
-                    confirmAction = () => { 
-                        errorMessage = ''; 
-                        $wire.call('approveSelected', selected);
-                        showConfirmModal = false;
-                    };
+                    let textPlural = selected.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Approve images') }}',
+                        message: '{{ __('You are about to approve') }} ' + selected.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, approve !') }}',
+                        confirmClass: 'bg-green-600 hover:bg-green-700',
+                        action: () => $wire.call('approveSelected', selected)
+                    })
                 }
             "
         icon="o-check"
@@ -177,11 +216,24 @@ new class extends Component {
     />
 
     <x-button 
-        @click=""
+        @click="if (selected.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selected.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Archive images') }}',
+                        message: '{{ __('You are about to archive') }} ' + selected.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, archive!') }}',
+                        confirmClass: 'bg-blue-600 hover:bg-blue-700',
+                        action: () => $wire.call('archiveSelected', selected)
+                    })
+                }
+            "
         icon="o-archive-box"
         class="btn btn-sm"
-        tooltip="{{ __('Archive Selected') }}"
-        aria-label="{{ __('Archive Selected') }}"
+        tooltip="{{ __('Archive selected') }}"
+        aria-label="{{ __('Archive selected') }}"
     />
     <x-button     
         @click="
@@ -189,16 +241,14 @@ new class extends Component {
                     errorMessage = '{{ __('No images selected.') }}'; 
                     setTimeout(() => errorMessage = '', 1500);
                 } else {
-                    modalTitle = '{{ __('Delete images') }}';
-                    modalMessage = '{{ __('You are about to delete') }} ' + selected.length + ' {{ __('images.') }}';
-                    modalConfirmText = '{{ __('Yes, delete !') }}';
-                    modalConfirmClass = 'bg-red-600 hover:bg-red-700';
-                    showConfirmModal = true; 
-                    confirmAction = () => { 
-                        errorMessage = ''; 
-                        $wire.call('deleteSelected', selected);
-                        showConfirmModal = false;
-                    };
+                    let textPlural = selected.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Delete images') }}',
+                        message: '{{ __('You are about to delete') }} ' + selected.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, delete !') }}',
+                        confirmClass: 'bg-red-600 hover:bg-red-700',
+                        action: () => $wire.call('deleteSelected', selected)
+                    })
                 }
             "
         icon="o-trash"
@@ -215,31 +265,42 @@ new class extends Component {
 
 
 <div class="gallery_wrapper">
-
-    @if($this->images()->isEmpty())
+    @if($this->images->isEmpty())
         <p class="text-center text-gray-500">{{ __('No image pending.') }}</p>
     @else
-        @foreach($this->images() as $image)
-        @if ($image->caption)
-        <div class="image_wrapper tooltip tooltip-bottom" data-tip="{{ __( $image->caption ) }}" wire:key="image-{{ $image->id }}">
+        @foreach($this->images as $image)
+        @php
+        if ($image->caption) {
+            $data1 = "tooltip tooltip-bottom";
+            $data2 = "$image->caption";
+            $data3 = "";
+        } else {
+            $data1 = "";
+            $data2 = "";
+            $data3 = "hidden";
+        }
+    @endphp
+        <div class="image_wrapper {{ ( $data1 ) }}" data-tip="{!! $data2 !!}" wire:key="image-{{ $image->id }}">
             <div class="uper_image_data justify-between">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                <a role="button" @click="$dispatch('open-image-modal', { url: '{{ asset('public/storage/' . $image->name) }}' })">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
+                    </svg>
+                </a>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 {{ ( $data3 ) }}">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
                 </svg>
-        @else
-        <div class="image_wrapper" wire:key="image-{{ $image->id }}">
-            <div class="uper_image_data justify-end">
-        @endif
             <input 
                 type="checkbox" 
-                class="checkbox checkbox-sm image-checkbox"
+                class="checkbox checkbox-sm unprocessed-image-checkbox"
                 :value="{{ $image->id }}"
                 x-model="selected"
+                id="checkbox-{{ $image->id }}"
             />
             </div>
-                <a href="{{ asset('storage/' . $image->name) }}" class="block">
-                    <img src="{{ asset('storage/' . $image->thumb) }}" />
-                </a>
+                <label for="checkbox-{{ $image->id }}" display="block">
+                    <img src="{{ asset('public/storage/' . $image->thumb) }}" />
+                </label>
             <div class="moderation_buttons flex justify-between">
                 <x-button 
                     wire:click="approveImage({{ $image->id }})"
@@ -250,7 +311,7 @@ new class extends Component {
                     @click="$wire.set('selectedImages', selected)"
                 />
                 <x-button 
-                    wire:click="archiveSelected"
+                    wire:click="archiveImage({{ $image->id }})"
                     icon="o-archive-box"
                     class="btn btn-sm"
                     tooltip="{{ __('Archive Selected') }}"
@@ -264,15 +325,13 @@ new class extends Component {
                     tooltip="{{ __('Delete image') }}"
                     aria-label="{{ __('Delete image') }}"
                     @click="
-                    modalTitle = '{{ __('Delete image') }}';
-                    modalMessage = '{{ __('Are you sure you want to delete this image?') }}';
-                    modalConfirmText = '{{ __('Yes, delete!') }}';
-                    modalConfirmClass = 'bg-red-600 hover:bg-red-700';
-                    confirmAction = () => { 
-                        $wire.call('deleteImage', {{ $image->id }});
-                        showConfirmModal = false;
-                    };
-                    showConfirmModal = true;
+                        $dispatch('confirm-action', {
+                            title: '{{ __('Delete image') }}',
+                            message: '{{ __('Are you sure you want to delete this image?') }}',
+                            confirmText: '{{ __('Yes, delete!') }}',
+                            confirmClass: 'bg-red-600 hover:bg-red-700',
+                            action: () => $wire.call('deleteImage', {{ $image->id }})
+                        })
                     "
                 />
             </div>
@@ -280,23 +339,10 @@ new class extends Component {
         @endforeach
     @endif
 </div>
+<div class="galerie-navigation flex justify-evenly">
+    {{ $this->images->links(data: ['scrollTo' => false]) }}
+</div>
 
 
-    <!-- Fenêtre modale dynamique (Validation & Suppression) -->
-    <div x-show="showConfirmModal" x-transition class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50">
-        <div class="bg-white p-6 rounded-lg shadow-lg w-96 overflow-auto relative">
-            <h2 class="text-lg font-semibold" x-text="modalTitle"></h2>
-            <p class="mt-2 text-gray-600" x-text="modalMessage"></p>
-
-            <div class="mt-4 flex justify-end space-x-2">
-                <button @click="showConfirmModal = false" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">
-                    {{ __('Cancel') }}
-                </button>
-                <button @click="confirmAction()" class="px-4 py-2 text-white rounded" :class="modalConfirmClass">
-                    <span x-text="modalConfirmText"></span>
-                </button>
-            </div>
-        </div>
-    </div>
 
 </div>

--- a/unprocessed-images.blade.php
+++ b/unprocessed-images.blade.php
@@ -1,0 +1,348 @@
+<?php
+
+use Livewire\Volt\Component;
+use App\Models\Wall;
+use App\Models\Image;
+use Intervention\Image\ImageManager;
+use Mary\Traits\Toast;
+use Illuminate\Support\Facades\Storage;
+use Livewire\WithPagination;
+use Livewire\WithoutUrlPagination;
+
+new class extends Component {
+    use Toast, WithPagination, WithoutUrlPagination;
+
+    public Wall $wall;   
+    public array $selectedImages = [];
+    public int $unprocessedImagesPageCount = 0;
+
+
+    public function mount(Wall $wall)
+    {
+        $this->wall = $wall;
+    }
+
+    public function getImagesProperty()
+    {
+        $images = Image::where('wall_id', $this->wall->id)
+                    ->where('approved', false)
+                    ->where('archived', false)
+                    ->orderBy('created_at', 'desc')
+                    ->paginate(5, pageName: 'unprocessed-images');
+
+        $this->unprocessedImagesPageCount = $images->count();
+        return $images;
+    }
+
+    // Approving images //
+    public function approveImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+       Image::where('id', $id)->update(['approved' => true]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Image approved successfully.'));
+    }
+
+    public function approveSelected(array $selectedImages)
+    {
+        
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+
+        Image::whereIn('id', $selectedImages)->update(['approved' => true]);
+
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant approved-images
+        $this->dispatch('approved-images-updated');
+        $this->success(__('Selected images approved.'));
+    }
+    
+
+    // Archiving images //
+    public function archiveImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+       Image::where('id', $id)->update(['archived' => true]);
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant archived-images
+        $this->dispatch('archived-images-updated');
+        $this->success(__('Image archived successfully.'));
+    }
+
+    public function archiveSelected(array $selectedImages)
+    {
+        
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+
+        Image::whereIn('id', $selectedImages)->update(['archived' => true]);
+
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        //  Émission d’événement Livewire vers le composant archived-images
+        $this->dispatch('archived-images-updated');
+        $this->success(__('Selected images archived.'));
+    }
+
+
+
+    // Deleting images //
+    public function deleteImage(int $id): void
+    {
+        // Récupérer directement les données nécessaires en une seule requête
+        $image = Image::where('id', $id)->first(['id', 'name', 'thumb']);
+    
+        if (!$image) {
+            $this->error(__('Image not found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers
+        Storage::disk('public')->delete([$image->name, $image->thumb]);
+    
+        // Supprimer l'image de la base de données
+        $image->delete();
+
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        $this->success(__('Image deleted successfully.'));
+    }
+
+    public function deleteSelected(array $selectedImages)
+    {
+       
+        if (empty($selectedImages)) {
+            $this->error(__('No images selected.'));
+            return;
+        }
+    
+        // Récupérer directement les chemins sous forme de liste plate
+        $paths = Image::whereIn('id', $selectedImages)->pluck('name')->merge(
+            Image::whereIn('id', $selectedImages)->pluck('thumb')
+        )->toArray();
+    
+        if (empty($paths)) {
+            $this->error(__('No valid images found.'));
+            return;
+        }
+    
+        // Supprimer les fichiers en une seule requête
+        Storage::disk('public')->delete($paths);
+    
+        // Supprimer les entrées de la base de données
+        Image::whereIn('id', $selectedImages)->delete();
+
+        // Réinitialiser la sélection
+        $this->dispatch('reset-selection');
+        // Reset la pagination uniquement si c'était la dernière image de la page
+        if ($this->unprocessedImagesPageCount <= 1) {
+            $this->resetPage(pageName: 'unprocessed-images');
+        }
+        $this->success(__('Selected images deleted.'));
+    }
+        
+}; ?>
+
+<div x-data="{ selected: [], allSelected: false,  errorMessage : '',
+        showConfirmModal: false, 
+        modalTitle: '', 
+        modalMessage: '', 
+        modalConfirmText: '', 
+        modalConfirmClass: 'bg-blue-600 hover:bg-blue-700', 
+        confirmAction: null,        
+        showImageZoomModal: false,
+        modalImageUrl: '' }" @reset-selection.window="selected = []; allSelected = false,  errorMessage = ''">
+
+<div class="galery_data">
+    <h2>{{ __( 'Pending images' ) }}</h2>
+</div>
+
+<div class="bulk-actions flex items-center">
+    <button class="btn btn-sm" @click="allSelected = !allSelected; selected = allSelected ? [...document.querySelectorAll('.unprocessed-image-checkbox')].map(cb => cb.value) : []">
+        <label for="select-all-checkbox" @click="allSelected = !allSelected; selected = allSelected ? [...document.querySelectorAll('.unprocessed-image-checkbox')].map(cb => cb.value) : []" class="cursor-pointer">Select All</label>
+        <input 
+            type="checkbox"
+            id="select-all-checkbox"
+            class="checkbox"
+            x-model="allSelected"
+        />
+    </button>
+
+    <x-button 
+        @click="
+                if (selected.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selected.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Approve images') }}',
+                        message: '{{ __('You are about to approve') }} ' + selected.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, approve !') }}',
+                        confirmClass: 'bg-green-600 hover:bg-green-700',
+                        action: () => $wire.call('approveSelected', selected)
+                    })
+                }
+            "
+        icon="o-check"
+        class="btn btn-sm"
+        tooltip="{{ __('Approve Selected') }}"
+        aria-label="{{ __('Approve Selected') }}"
+    />
+
+    <x-button 
+        @click="if (selected.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selected.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Archive images') }}',
+                        message: '{{ __('You are about to archive') }} ' + selected.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, archive!') }}',
+                        confirmClass: 'bg-blue-600 hover:bg-blue-700',
+                        action: () => $wire.call('archiveSelected', selected)
+                    })
+                }
+            "
+        icon="o-archive-box"
+        class="btn btn-sm"
+        tooltip="{{ __('Archive selected') }}"
+        aria-label="{{ __('Archive selected') }}"
+    />
+    <x-button     
+        @click="
+                if (selected.length === 0) { 
+                    errorMessage = '{{ __('No images selected.') }}'; 
+                    setTimeout(() => errorMessage = '', 1500);
+                } else {
+                    let textPlural = selected.length === 1 ? '{{ __('image') }}' : '{{ __('images') }}';
+                    $dispatch('confirm-action', {
+                        title: '{{ __('Delete images') }}',
+                        message: '{{ __('You are about to delete') }} ' + selected.length + ' ' + textPlural + '.',
+                        confirmText: '{{ __('Yes, delete !') }}',
+                        confirmClass: 'bg-red-600 hover:bg-red-700',
+                        action: () => $wire.call('deleteSelected', selected)
+                    })
+                }
+            "
+        icon="o-trash"
+        class="btn btn-sm btn-danger"
+        wire:click.prevent=""
+        tooltip="{{ __('Delete Selected') }}"
+        aria-label="{{ __('Delete Selected') }}"
+    />
+    <!-- Message d'erreur affiché dynamiquement -->
+    <p x-show="errorMessage" x-text="errorMessage" class="text-red-500 mt-2 transition-opacity duration-500"></p>
+    <p wire:loading>Please wait...</p>
+    
+</div>
+
+
+<div class="gallery_wrapper">
+    @if($this->images->isEmpty())
+        <p class="text-center text-gray-500">{{ __('No image pending.') }}</p>
+    @else
+        @foreach($this->images as $image)
+        @php
+        if ($image->caption) {
+            $data1 = "tooltip tooltip-bottom";
+            $data2 = "$image->caption";
+            $data3 = "";
+        } else {
+            $data1 = "";
+            $data2 = "";
+            $data3 = "hidden";
+        }
+    @endphp
+        <div class="image_wrapper {{ ( $data1 ) }}" data-tip="{!! $data2 !!}" wire:key="image-{{ $image->id }}">
+            <div class="uper_image_data justify-between">
+                <a role="button" @click="$dispatch('open-image-modal', { url: '{{ asset('public/storage/' . $image->name) }}' })">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
+                    </svg>
+                </a>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 {{ ( $data3 ) }}">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                </svg>
+            <input 
+                type="checkbox" 
+                class="checkbox checkbox-sm unprocessed-image-checkbox"
+                :value="{{ $image->id }}"
+                x-model="selected"
+                id="checkbox-{{ $image->id }}"
+            />
+            </div>
+                <label for="checkbox-{{ $image->id }}" display="block">
+                    <img src="{{ asset('public/storage/' . $image->thumb) }}" />
+                </label>
+            <div class="moderation_buttons flex justify-between">
+                <x-button 
+                    wire:click="approveImage({{ $image->id }})"
+                    icon="o-check"
+                    class="btn btn-sm"
+                    tooltip="{{ __('Approve image') }}"
+                    aria-label="{{ __('Approve image') }}"
+                    @click="$wire.set('selectedImages', selected)"
+                />
+                <x-button 
+                    wire:click="archiveImage({{ $image->id }})"
+                    icon="o-archive-box"
+                    class="btn btn-sm"
+                    tooltip="{{ __('Archive Selected') }}"
+                    aria-label="{{ __('Archive Selected') }}"
+                    @click="$wire.set('selectedImages', selected)"
+                />
+                <x-button 
+                    wire:click.prevent=""
+                    icon="o-trash"
+                    class="btn btn-sm btn-danger"
+                    tooltip="{{ __('Delete image') }}"
+                    aria-label="{{ __('Delete image') }}"
+                    @click="
+                        $dispatch('confirm-action', {
+                            title: '{{ __('Delete image') }}',
+                            message: '{{ __('Are you sure you want to delete this image?') }}',
+                            confirmText: '{{ __('Yes, delete!') }}',
+                            confirmClass: 'bg-red-600 hover:bg-red-700',
+                            action: () => $wire.call('deleteImage', {{ $image->id }})
+                        })
+                    "
+                />
+            </div>
+        </div>
+        @endforeach
+    @endif
+</div>
+<div class="galerie-navigation flex justify-evenly">
+    {{ $this->images->links(data: ['scrollTo' => false]) }}
+</div>
+
+
+
+</div>


### PR DESCRIPTION
Moved the modals html from unprocessed, approved and archived files to the parent (moderation). Now called from the childs with @dispatch. Modals called for zoom, image delete, and multiple images selected approve, archive, delete. Added plural option to the confirmation modal.